### PR TITLE
kstdlib: Fix bug in kprintf and rework memcmp

### DIFF
--- a/kernel/kstdlib/kprintf.cpp
+++ b/kernel/kstdlib/kprintf.cpp
@@ -47,12 +47,12 @@ static constexpr const char* digits = "0123456789abcdef";
 
     memset(buff, 0, 512);
     int i = 0;
-    while(number)
+    do
     {
         buff[i++] = '0' + (number % 10);
         number /= 10;
         ret++;
-    }
+    } while(number);
 
     int len = strlen(buff);
     UNUSED(len);

--- a/kernel/kstdlib/kstring.cpp
+++ b/kernel/kstdlib/kstring.cpp
@@ -54,11 +54,11 @@ int memcmp(void* src, void* target, size_t num)
     const uint8_t* str_ptr = reinterpret_cast<uint8_t*>(src);
     const uint8_t* target_ptr = reinterpret_cast<uint8_t*>(target);
 
-    while(num--)
+    for(int i = 0; i < static_cast<int>(num); ++i)
     {
-        if(*str_ptr < *target_ptr)
+        if(*(str_ptr + i) < *(target_ptr + i))
             return -1;
-        if(*str_ptr > *target_ptr)
+        if(*(str_ptr + i) > *(target_ptr + i))
             return 1;
     }
 


### PR DESCRIPTION
The 'kprintf_internal_number' function was not printing anything when 0 was passed in.

The 'memcmp' function was not implemented correctly.